### PR TITLE
updating /codalab/apps/web/views.py - changed results_to_respose to u…

### DIFF
--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1343,7 +1343,8 @@ class MyCompetitionSubmissionDetailedResults(TemplateView):
             'user': submission.participant.user,
             'submission': submission,
         }
-        return render_to_response('web/my/detailed_results.html', context_dict, RequestContext(request))
+        return render(request, 'web/my/detailed_results.html', context=context_dict)
+#        return render_to_response('web/my/detailed_results.html', context_dict, RequestContext(request))
 
 
 class MyCompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):


### PR DESCRIPTION
…pdated render call due to deprecation of results_to_response

# Template
This is a template. While not all sections are necessary, depending on the size and complexity of the PR,
more information is better. 

# @ mention of reviewers
...


# A brief description of the purpose of the changes contained in this PR.
...

# Issues this PR resolves
...


# A checklist for hand testing
- [ ] add checklist here


# Any relevant files for testing
[link]('#') to any relevant files (or drag and drop into github)


# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge
